### PR TITLE
Read packed refs.

### DIFF
--- a/repo_tag.go
+++ b/repo_tag.go
@@ -17,7 +17,7 @@ func (repo *Repository) TagPath(tagName string) string {
 
 // GetTags returns all tags of given repository.
 func (repo *Repository) GetTags() ([]string, error) {
-	return repo.readRefDir("refs/tags", "")
+	return repo.readRefDir("refs/tags", "", true)
 }
 
 func (repo *Repository) CreateTag(tagName, idStr string) error {


### PR DESCRIPTION
When reading references it was not accounting for the packed references
insided the packed-ref file. Packed refs are only included in the list
if there is no unpacked references with the same name.

This was breaking builds on go-vcs.
