### PR TITLE
Expose getCommitIdOfRef as public function

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -35,7 +35,7 @@ func (repo *Repository) GetCommitOfBranch(branchName string) (*Commit, error) {
 }
 
 func (repo *Repository) GetCommitIdOfBranch(branchName string) (string, error) {
-	return repo.getCommitIdOfRef("refs/heads/" + branchName)
+	return repo.GetCommitIdOfRef("refs/heads/" + branchName)
 }
 
 func (repo *Repository) GetCommitOfTag(tagName string) (*Commit, error) {
@@ -48,10 +48,10 @@ func (repo *Repository) GetCommitOfTag(tagName string) (*Commit, error) {
 }
 
 func (repo *Repository) GetCommitIdOfTag(tagName string) (string, error) {
-	return repo.getCommitIdOfRef("refs/tags/" + tagName)
+	return repo.GetCommitIdOfRef("refs/tags/" + tagName)
 }
 
-func (repo *Repository) getCommitIdOfRef(refpath string) (string, error) {
+func (repo *Repository) GetCommitIdOfRef(refpath string) (string, error) {
 start:
 	path := filepath.Join(repo.Path, refpath)
 	f, err := ioutil.ReadFile(path)


### PR DESCRIPTION
Use case, retrieving GetCommitIdOfRef("HEAD")
